### PR TITLE
Use glob to check if SAVE_PATH exists;Imporve Saliency map value;Use …

### DIFF
--- a/assignment3/NetworkVisualization-TensorFlow.ipynb
+++ b/assignment3/NetworkVisualization-TensorFlow.ipynb
@@ -24,7 +24,9 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "# As usual, a bit of setup\n",
@@ -153,7 +155,9 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "X = np.array([preprocess_image(img) for img in X_raw])"
@@ -177,7 +181,9 @@
   {
    "cell_type": "code",
    "execution_count": 5,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def compute_saliency_maps(X, y, model):\n",
@@ -209,7 +215,7 @@
     "    # Note: model.image and model.labels are placeholders and must be fed values  #\n",
     "    # when you call sess.run().                                                   #\n",
     "    ###############################################################################\n",
-    "    loss = tf.square(1 - correct_scores)\n",
+    "    loss = correct_scores\n",
     "    grad_img = tf.gradients(loss,model.image)\n",
     "    grad_img_val = sess.run(grad_img,feed_dict={model.image:X,model.labels:y})[0]\n",
     "    saliency = np.sum(np.maximum(grad_img_val,0),axis=3)\n",
@@ -278,7 +284,9 @@
   {
    "cell_type": "code",
    "execution_count": 7,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def make_fooling_image(X, target_y, model):\n",
@@ -311,17 +319,18 @@
     "    # You can print your progress over iterations to check your algorithm.       #\n",
     "    ##############################################################################    \n",
     "\n",
+    "    g = tf.gradients(model.classifier[0,target_y],model.image)[0]\n",
+    "    dX = learning_rate * g / tf.norm(g)\n",
+    "    \n",
     "    for i in range(100):\n",
     "        scores = sess.run(model.classifier,{model.image:X_fooling})\n",
     "        print('step:%d,current_label_score:%f,target_label_score:%f' % \\\n",
     "              (i,scores[0].max(),scores[0][target_y]))\n",
     "        if scores[0].argmax() == target_y:\n",
     "            break\n",
-    "        \n",
-    "        g = tf.gradients(model.classifier[0,target_y],model.image)[0]\n",
-    "        g_val = sess.run(g,feed_dict={model.image:X_fooling})\n",
-    "        dX = learning_rate * g_val / np.sum(g_val)\n",
-    "        X_fooling += dX     \n",
+    "\n",
+    "        np_dX = sess.run(dX, feed_dict={model.image:X_fooling})\n",
+    "        X_fooling += np_dX     \n",
     "        \n",
     "    \n",
     "    ##############################################################################\n",
@@ -443,7 +452,9 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {},
+   "metadata": {
+    "collapsed": true
+   },
    "outputs": [],
    "source": [
     "def create_class_visualization(target_y, model, **kwargs):\n",


### PR DESCRIPTION
1. 
Use glob to check if SAVE_PATH exists, beacause the squeezenet checkpoint has three files actually.
[Reference](https://github.com/cs231n/cs231n.github.io/issues/165)
2.
`loss = correct_scores # not tf.square(1-correct_scores)`
Experiment shows it can have clearer saliency map.
3.
`dX = learning_rate * g / tf.norm(g)`
instead of **tf.reduce_sum** can generate a fooling image with fewer noise. It is clearer while inputing a **quail** image.


